### PR TITLE
Fix dockerfile with build step and agnostic build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,32 @@
-FROM nginx:latest
+ARG CUSTOM_DIRECTUS_URL=directus.example.com
+ARG CUSTOM_PRERENDER_URL=prerender.example.com
+
+FROM node:14 as build
+WORKDIR /app
+ARG CUSTOM_DIRECTUS_URL
+ARG CUSTOM_PRERENDER_URL
+ENV VUE_APP_DIRECTUS_URL=$CUSTOM_DIRECTUS_URL
+ENV VUE_APP_PRERENDER_DOMAIN=$CUSTOM_PRERENDER_URL
+ENV VUE_APP_I18N_LOCALE=en-us
+ENV VUE_APP_LANGUAGES=en-us
+ENV VUE_APP_API_URL=https://$VUE_APP_DIRECTUS_URL
+ENV VUE_APP_TEAM_API=https://$VUE_APP_DIRECTUS_URL/items/team_members?fields=*.*&sort%5B%5D=sort&limit=-1
+ENV VUE_APP_ASSET_URL=https://$VUE_APP_DIRECTUS_URL/assets/
+ENV VUE_APP_ITEMS_URL=https://$VUE_APP_DIRECTUS_URL/items/
+ENV VUE_APP_ZOHO_ENDPOINT=https://oitn.maillist-manage.eu/weboptin.zc
+
+COPY . /app
+RUN yarn install
+RUN yarn build
+
+FROM nginx:latest as serve
+ARG CUSTOM_DIRECTUS_URL
+ARG CUSTOM_PRERENDER_URL
+ENV CUSTOM_DIRECTUS_URL $CUSTOM_DIRECTUS_URL
+ENV CUSTOM_PRERENDER_URL $CUSTOM_PRERENDER_URL
 
 COPY ./docker/nginx.conf /etc/nginx/nginx.conf
-COPY ./docker/nginx-default.conf /etc/nginx/conf.d/default.conf
-COPY ./dist /var/www/html
+COPY ./docker/nginx-default.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build ./app/dist /var/www/html
 
 EXPOSE 80

--- a/docker/nginx-default.conf.template
+++ b/docker/nginx-default.conf.template
@@ -7,6 +7,9 @@ server {
     location / {
         try_files $uri $uri/ /index.html$is_args$args @prerender;
         autoindex on;
+        sub_filter 'prerender.example.com' $CUSTOM_PRERENDER_DOMAIN;
+        sub_filter 'directus.example.com' $CUSTOM_DIRECTUS_DOMAIN;
+        sub_filter_once on;
     }
 
     location @prerender {
@@ -30,7 +33,7 @@ server {
         if ($prerender = 1) {
 
             #setting prerender as a variable forces DNS resolution since nginx caches IPs and doesnt play well with load balancing
-            set $prerender "${PRERENDER_DOMAIN}";
+            set $prerender "${CUSTOM_PRERENDER_DOMAIN}";
             rewrite .* /$scheme://$host$request_uri? break;
             proxy_pass http://$prerender;
         }
@@ -39,4 +42,5 @@ server {
         }
     }
 }
+
 


### PR DESCRIPTION
First draft of the Dockerfile with the build step that would allow agnostic container build independent from environment.

An nginx template would replace the placeholder prerender.example.com with any custom env variable named CUSTOM_PRERENDER_DOMAIN at runtime (Same logic applies for the directus domain name).

This is a way to do it that does not require too much time given the strict deadline.
The only limitation is that the env variables are replaced in the default.conf template only at the first run. This is not necessarily a drawbach as per the ephemeral and stateless nature of docker containers.
If you want to have other pointers, you can just re-create the container.

@sd-ditoy Waiting for your changes so that we are able to apply the sub_filters on the placeholders.
