### PR TITLE
Bradjohnl/feature/lint and dep analisys

### DIFF
--- a/.github/check.yml
+++ b/.github/check.yml
@@ -1,0 +1,48 @@
+---
+#TODO: Find a way to test "yarn dev" and "yarn preview" in the CI
+
+name: Check code base
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: "*"
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Lint Code Base (PR against development branch)
+        # yamllint disable-line rule:line-length
+        if: github.event_name == 'pull_request' && github.base_ref == 'development'
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: ${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint Code Base (against PR base branch)
+        # yamllint disable-line rule:line-length
+        if: github.event_name == 'pull_request' && github.base_ref != 'development'
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: ${{ github.base_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+
+      - name: Lint Code Base (against current branch)
+        if: github.event_name == 'push'
+        uses: github/super-linter/slim@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: ${{ github.head_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: ${{ github.base_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
 
       - name: Lint Code Base (against PR base branch)
         # yamllint disable-line rule:line-length
@@ -46,3 +47,6 @@ jobs:
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: 'high'
+          base-ref: ${{ github.base_ref }}


### PR DESCRIPTION
CHANGES:
- Dependency check for vulnerabilities. Will tell use when we have to upgrade.
- Comprehensive linter. For now enforcing it's disabled, but it's worth having a look at the action logs to figure out some recommendations and for formatting consinstency. The objective it to enforce linting and formatting (not on everything though). Some rules can be ignored by placing comments such as: # yamllint disable-line rule:line-length.

In the near future, we will discuss about using linters to match the CI linters config so that we don't have to worry about formatting differences and the PRs are easier to manage and read.
pre-commit is a good candidate for that. 