### PR TITLE
Fixing dep review

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           fail-on-severity: 'high'
           base-ref: ${{ github.base_ref }}
+          head-ref: ${{ github.head_ref }}


### PR DESCRIPTION
Small fix to the GH action for dep review which requires also the hard-reference to be specified