### PR TITLE
Bradjohnl/fix/dep review 3

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -1,0 +1,21 @@
+---
+name: Check dependencies
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  run-linters:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: 'Dependency Review'
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: 'high'
+          base-ref: ${{ github.base_ref }}
+          head-ref: ${{ github.head_ref }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,17 +1,14 @@
 ---
-#TODO: Find a way to test "yarn dev" and "yarn preview" in the CI
-
-name: Check code base
+name: Run linters
 
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: "*"
   pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
-  check:
+  run-linters:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -44,10 +41,3 @@ jobs:
           DEFAULT_BRANCH: ${{ github.head_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISABLE_ERRORS: true
-
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
-        with:
-          fail-on-severity: 'high'
-          base-ref: ${{ github.base_ref }}
-          head-ref: ${{ github.head_ref }}


### PR DESCRIPTION
Splitting the workflows into 2 parallel ones and letting the dependency review trigger on PR only as it does not work on push.